### PR TITLE
Remove dynamic team parameter updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,7 @@ control the share of matches ending in a draw and the bias towards the home
 team. By default these values are kept fixed using the historical averages
 `DEFAULT_TIE_PERCENT` (27.0) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.7).
 Pass `--dynamic-params` to recalculate them from the games already played in
-the data set. Team statistics can be updated after each simulated match so that
-probabilities adapt as the simulation progresses. Enable this behaviour with
-`--update-team-params` or leave it disabled for faster runs. `DEFAULT_JOBS`
-still defines the parallelism level. The `--alpha` option controls the
-smoothing factor applied when updating dynamic team parameters and must be
-between 0 and 1. The default value is 0.1.
+the data set. `DEFAULT_JOBS` still defines the parallelism level.
 
 Matches are simulated purely at random with all teams considered equal.
 

--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ from brasileirao.simulator import (
 
 # Default behaviour uses a simple model without recalculating parameters
 DEFAULT_DYNAMIC_PARAMS = False
-DEFAULT_DYNAMIC_TEAM_PARAMS = False
 
 
 def main() -> None:
@@ -64,13 +63,6 @@ def main() -> None:
         action="store_true",
         default=DEFAULT_DYNAMIC_PARAMS,
         help="estimate tie percent and home advantage from played matches",
-    )
-    parser.add_argument(
-        "--update-team-params",
-        dest="dynamic_team_params",
-        action="store_true",
-        default=DEFAULT_DYNAMIC_TEAM_PARAMS,
-        help="adjust per-team parameters dynamically during the simulation",
     )
     def alpha_type(value: str) -> float:
         try:
@@ -132,7 +124,6 @@ def main() -> None:
         home_field_adv=home_adv,
         tie_prob_map=tie_map,
         home_advantage_map=home_map,
-        dynamic_team_params=args.dynamic_team_params,
         alpha=args.alpha,
         n_jobs=args.jobs,
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -204,28 +204,6 @@ def test_dynamic_params_deterministic():
     pd.testing.assert_frame_equal(t1, t2)
 
 
-def test_dynamic_team_params_deterministic():
-    df = parse_matches("data/Brasileirao2024A.txt")
-    rng = np.random.default_rng(7)
-    t1 = simulator.summary_table(
-        df,
-        iterations=5,
-        rng=rng,
-        progress=False,
-        dynamic_team_params=True,
-        n_jobs=2,
-    )
-    rng = np.random.default_rng(7)
-    t2 = simulator.summary_table(
-        df,
-        iterations=5,
-        rng=rng,
-        progress=False,
-        dynamic_team_params=True,
-        n_jobs=2,
-    )
-    pd.testing.assert_frame_equal(t1, t2)
-
 
 def test_alpha_validation_private():
     played = pd.DataFrame(


### PR DESCRIPTION
## Summary
- drop unused `--update-team-params` CLI option
- simplify simulation functions by removing dynamic team updates
- update docs and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a814568188325b73d9a989fe8c1b1