### PR TITLE
Fix CLI params

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,8 @@ example will execute the Monte Carlo iterations using four parallel processes.
 The summary table is automatically saved as `brasileirao.html` in the same
 directory as `main.py`. Pass `--html-output <file>` to choose a custom path.
 
-The simulator also accepts `--tie-percent` and `--home-advantage` options to
-control the share of matches ending in a draw and the bias towards the home
-team. By default these values are kept fixed using the historical averages
-`DEFAULT_TIE_PERCENT` (27.0) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.7).
+The draw rate and home-field advantage are fixed at
+`DEFAULT_TIE_PERCENT` (33.3) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.0).
 `DEFAULT_JOBS` still defines the parallelism level.
 
 Matches are simulated purely at random with all teams considered equal.
@@ -68,8 +66,8 @@ from brasileirao import (
 All simulation functions accept an optional ``n_jobs`` argument to control the
 degree of parallelism. By default ``n_jobs`` is set to the number of CPU cores,
 so simulations automatically run in parallel. When ``n_jobs`` is greater than
-one, joblib is used to distribute the work across multiple workers. By default
-the tie percentage and home advantage are kept fixed.
+one, joblib is used to distribute the work across multiple workers. The tie
+percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
 
 ## License
 

--- a/main.py
+++ b/main.py
@@ -44,34 +44,6 @@ def main() -> None:
         help="disable the progress bar during simulations",
     )
     parser.add_argument(
-        "--tie-percent",
-        type=float,
-        default=DEFAULT_TIE_PERCENT,
-        help="percent of games ending in a tie",
-    )
-    parser.add_argument(
-        "--home-advantage",
-        type=float,
-        default=DEFAULT_HOME_FIELD_ADVANTAGE,
-        help="home field advantage factor",
-    )
-    def alpha_type(value: str) -> float:
-        try:
-            val = float(value)
-        except ValueError as exc:  # pragma: no cover - argparse handles error
-            raise argparse.ArgumentTypeError("alpha must be a number") from exc
-        if not 0.0 <= val <= 1.0:
-            raise argparse.ArgumentTypeError(
-                "alpha must be between 0 and 1"
-            )
-        return val
-    parser.add_argument(
-        "--alpha",
-        type=alpha_type,
-        default=DEFAULT_ALPHA,
-        help="smoothing factor for dynamic team parameters",
-    )
-    parser.add_argument(
         "--jobs",
         type=int,
         default=DEFAULT_JOBS,
@@ -86,8 +58,10 @@ def main() -> None:
 
     matches = parse_matches(args.file)
     rng = np.random.default_rng(args.seed) if args.seed is not None else None
-    tie_prob = args.tie_percent / 100.0
-    home_adv = args.home_advantage
+    # Fixed simulation parameters
+    tie_prob = DEFAULT_TIE_PERCENT / 100.0
+    home_adv = DEFAULT_HOME_FIELD_ADVANTAGE
+    alpha = DEFAULT_ALPHA
 
     summary = summary_table(
         matches,
@@ -96,7 +70,7 @@ def main() -> None:
         progress=args.progress,
         tie_prob=tie_prob,
         home_field_adv=home_adv,
-        alpha=args.alpha,
+        alpha=alpha,
         n_jobs=args.jobs,
     )
     if args.html_output:

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -28,13 +28,12 @@ import pandas as pd
 # ---------------------------------------------------------------------------
 
 # Percent chance of a match ending in a tie when teams are of equal strength
-# Based on the 2022-2024 seasons where ~27% of games finished level.
-DEFAULT_TIE_PERCENT = 27.0
+# Fixed at one third of matches ending level.
+DEFAULT_TIE_PERCENT = 33.3
 
 # Relative advantage multiplier for the home team
-# Calculated from past results where home wins occurred about 1.7 times as
-# often as away wins.
-DEFAULT_HOME_FIELD_ADVANTAGE = 1.7
+# No built-in home advantage is used by default.
+DEFAULT_HOME_FIELD_ADVANTAGE = 1.0
 
 # Default number of parallel jobs. Use all available cores.
 DEFAULT_JOBS = os.cpu_count() or 1


### PR DESCRIPTION
## Summary
- remove `--tie-percent`, `--home-advantage` and `--alpha` arguments from the CLI
- fix draw rate to 33.3% and disable home advantage by default
- document fixed parameters in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8853963c8325b7207807d1256d4f