### PR TITLE
Fix: constant home advantage

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ import pandas as pd
 
 from brasileirao import parse_matches, summary_table
 from brasileirao.simulator import (
-    DEFAULT_HOME_FIELD_ADVANTAGE,
     DEFAULT_JOBS,
     DEFAULT_TIE_PERCENT,
 )
@@ -59,7 +58,6 @@ def main() -> None:
     rng = np.random.default_rng(args.seed) if args.seed is not None else None
     # Fixed simulation parameters
     tie_prob = DEFAULT_TIE_PERCENT / 100.0
-    home_adv = DEFAULT_HOME_FIELD_ADVANTAGE
 
     summary = summary_table(
         matches,
@@ -67,7 +65,6 @@ def main() -> None:
         rng=rng,
         progress=args.progress,
         tie_prob=tie_prob,
-        home_field_adv=home_adv,
         n_jobs=args.jobs,
     )
     if args.html_output:

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -203,15 +203,14 @@ def _simulate_table(
     rng: np.random.Generator,
     *,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
-    home_field_adv: float = DEFAULT_HOME_FIELD_ADVANTAGE,
 ) -> pd.DataFrame:
-    """Simulate remaining fixtures with adjustable probabilities."""
+    """Simulate remaining fixtures with fixed home advantage."""
 
     sims: list[dict] = []
 
     for _, row in remaining.iterrows():
         tp = tie_prob
-        ha = home_field_adv
+        ha = DEFAULT_HOME_FIELD_ADVANTAGE
         rest = 1.0 - tp
         home_prob = rest * ha / (ha + 1)
         draw_prob = tp
@@ -247,7 +246,6 @@ def simulate_chances(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
-    home_field_adv: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> Dict[str, float]:
     """Return title probabilities.
@@ -278,7 +276,6 @@ def simulate_chances(
                 remaining,
                 np.random.default_rng(seed),
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
 
         results = Parallel(n_jobs=n_jobs)(delayed(run)(s) for s in iterator)
@@ -294,7 +291,6 @@ def simulate_chances(
                 remaining,
                 rng,
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
             champs[table.iloc[0]["team"]] += 1
 
@@ -310,7 +306,6 @@ def simulate_relegation_chances(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
-    home_field_adv: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> Dict[str, float]:
     """Return probabilities of finishing in the bottom four."""
@@ -338,7 +333,6 @@ def simulate_relegation_chances(
                 remaining,
                 np.random.default_rng(seed),
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
 
         results = Parallel(n_jobs=n_jobs)(delayed(run)(s) for s in iterator)
@@ -355,7 +349,6 @@ def simulate_relegation_chances(
                 remaining,
                 rng,
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
             for team in table.tail(4)["team"]:
                 relegated[team] += 1
@@ -372,7 +365,6 @@ def simulate_final_table(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
-    home_field_adv: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> pd.DataFrame:
     """Project average finishing position and points."""
@@ -402,7 +394,6 @@ def simulate_final_table(
                 remaining,
                 np.random.default_rng(seed),
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
 
         results = Parallel(n_jobs=n_jobs)(delayed(run)(s) for s in iterator)
@@ -420,7 +411,6 @@ def simulate_final_table(
                 remaining,
                 rng,
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
             for idx, row in table.iterrows():
                 pos_totals[row["team"]] += idx + 1
@@ -448,7 +438,6 @@ def summary_table(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
-    home_field_adv: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> pd.DataFrame:
     """Return a combined projection table ranked by expected points.
@@ -483,7 +472,6 @@ def summary_table(
                 remaining,
                 np.random.default_rng(seed),
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
 
         results = Parallel(n_jobs=n_jobs)(delayed(run)(s) for s in iterator)
@@ -504,7 +492,6 @@ def summary_table(
                 remaining,
                 rng,
                 tie_prob=tie_prob,
-                home_field_adv=home_field_adv,
             )
             title_counts[table.iloc[0]["team"]] += 1
             for team in table.tail(4)["team"]:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -127,7 +127,6 @@ def test_simulate_table_no_draws_when_zero_tie():
         remaining,
         rng,
         tie_prob=0.0,
-        home_field_adv=1.0,
     )
     assert table["draws"].sum() == 0
 
@@ -140,7 +139,6 @@ def test_simulate_final_table_custom_params_deterministic():
         iterations=5,
         rng=rng,
         tie_prob=0.2,
-        home_field_adv=1.5,
         n_jobs=2,
     )
     rng = np.random.default_rng(9)
@@ -149,7 +147,6 @@ def test_simulate_final_table_custom_params_deterministic():
         iterations=5,
         rng=rng,
         tie_prob=0.2,
-        home_field_adv=1.5,
         n_jobs=2,
     )
     pd.testing.assert_frame_equal(t1, t2)


### PR DESCRIPTION
## Summary
- remove `home_field_adv` tuning and use constant value
- adjust CLI to remove unused import and param
- update tests accordingly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a90e1c28c8325acf4bb473233af79