### PR TITLE
Add customizable home advantage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ directory as `main.py`. Pass `--html-output <file>` to choose a custom path.
 Use `--from-date YYYY-MM-DD` to ignore results on or after a given date and
 simulate from that point forward.
 
-The draw rate and home-field advantage are fixed at
+The default draw rate and home-field advantage are
 `DEFAULT_TIE_PERCENT` (33.3) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.0).
-`DEFAULT_JOBS` still defines the parallelism level.
+Use `--tie-percent` and `--home-advantage` to override these values on the
+command line. `DEFAULT_JOBS` still defines the parallelism level.
 
 Matches are simulated purely at random with all teams considered equal.
 

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from simulator import (
     summary_table,
     DEFAULT_JOBS,
     DEFAULT_TIE_PERCENT,
+    DEFAULT_HOME_FIELD_ADVANTAGE,
 )
 
 
@@ -49,6 +50,18 @@ def main() -> None:
         help="number of parallel workers",
     )
     parser.add_argument(
+        "--tie-percent",
+        type=float,
+        default=DEFAULT_TIE_PERCENT,
+        help="percent chance of a match ending in a draw",
+    )
+    parser.add_argument(
+        "--home-advantage",
+        type=float,
+        default=DEFAULT_HOME_FIELD_ADVANTAGE,
+        help="relative advantage multiplier for the home team",
+    )
+    parser.add_argument(
         "--from-date",
         dest="from_date",
         default=None,
@@ -66,8 +79,8 @@ def main() -> None:
         from_date = pd.to_datetime(args.from_date)
         matches.loc[matches["date"] >= from_date, ["home_score", "away_score"]] = np.nan
     rng = np.random.default_rng(args.seed) if args.seed is not None else None
-    # Fixed simulation parameters
-    tie_prob = DEFAULT_TIE_PERCENT / 100.0
+    tie_prob = args.tie_percent / 100.0
+    home_adv = args.home_advantage
 
     summary = summary_table(
         matches,
@@ -75,6 +88,7 @@ def main() -> None:
         rng=rng,
         progress=args.progress,
         tie_prob=tie_prob,
+        home_advantage=home_adv,
         n_jobs=args.jobs,
     )
     if args.html_output:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,9 @@ from .simulator import (
     simulate_relegation_chances,
     simulate_final_table,
     summary_table,
+    DEFAULT_TIE_PERCENT,
+    DEFAULT_HOME_FIELD_ADVANTAGE,
+    DEFAULT_JOBS,
 )
 
 __all__ = [
@@ -18,4 +21,7 @@ __all__ = [
     "simulate_relegation_chances",
     "simulate_final_table",
     "summary_table",
+    "DEFAULT_TIE_PERCENT",
+    "DEFAULT_HOME_FIELD_ADVANTAGE",
+    "DEFAULT_JOBS",
 ]

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -213,6 +213,7 @@ def _simulate_table(
     rng: np.random.Generator,
     *,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
+    home_advantage: float = DEFAULT_HOME_FIELD_ADVANTAGE,
 ) -> pd.DataFrame:
     """Simulate remaining fixtures with fixed home advantage."""
 
@@ -220,7 +221,7 @@ def _simulate_table(
 
     for _, row in remaining.iterrows():
         tp = tie_prob
-        ha = DEFAULT_HOME_FIELD_ADVANTAGE
+        ha = home_advantage
         rest = 1.0 - tp
         home_prob = rest * ha / (ha + 1)
         draw_prob = tp
@@ -253,6 +254,7 @@ def _iterate_tables(
     desc: str,
     progress: bool,
     tie_prob: float,
+    home_advantage: float,
     n_jobs: int,
 ):
     """Yield successive simulated tables.
@@ -273,6 +275,7 @@ def _iterate_tables(
                 remaining,
                 np.random.default_rng(seed),
                 tie_prob=tie_prob,
+                home_advantage=home_advantage,
             )
 
         results = Parallel(n_jobs=n_jobs)(delayed(run)(s) for s in iterator)
@@ -288,6 +291,7 @@ def _iterate_tables(
                 remaining,
                 rng,
                 tie_prob=tie_prob,
+                home_advantage=home_advantage,
             )
 
 
@@ -303,6 +307,7 @@ def simulate_chances(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
+    home_advantage: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> Dict[str, float]:
     """Return title probabilities.
@@ -329,6 +334,7 @@ def simulate_chances(
         desc="Chances",
         progress=progress,
         tie_prob=tie_prob,
+        home_advantage=home_advantage,
         n_jobs=n_jobs,
     ):
         champs[table.iloc[0]["team"]] += 1
@@ -345,6 +351,7 @@ def simulate_relegation_chances(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
+    home_advantage: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> Dict[str, float]:
     """Return probabilities of finishing in the bottom four."""
@@ -368,6 +375,7 @@ def simulate_relegation_chances(
         desc="Relegation",
         progress=progress,
         tie_prob=tie_prob,
+        home_advantage=home_advantage,
         n_jobs=n_jobs,
     ):
         for team in table.tail(4)["team"]:
@@ -385,6 +393,7 @@ def simulate_final_table(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
+    home_advantage: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> pd.DataFrame:
     """Project average finishing position and points."""
@@ -410,6 +419,7 @@ def simulate_final_table(
         desc="Final table",
         progress=progress,
         tie_prob=tie_prob,
+        home_advantage=home_advantage,
         n_jobs=n_jobs,
     ):
         for idx, row in table.iterrows():
@@ -438,6 +448,7 @@ def summary_table(
     rng: np.random.Generator | None = None,
     progress: bool = True,
     tie_prob: float = DEFAULT_TIE_PERCENT / 100.0,
+    home_advantage: float = DEFAULT_HOME_FIELD_ADVANTAGE,
     n_jobs: int = DEFAULT_JOBS,
 ) -> pd.DataFrame:
     """Return a combined projection table ranked by expected points.
@@ -468,6 +479,7 @@ def summary_table(
         desc="Summary",
         progress=progress,
         tie_prob=tie_prob,
+        home_advantage=home_advantage,
         n_jobs=n_jobs,
     ):
         title_counts[table.iloc[0]["team"]] += 1

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -139,6 +139,7 @@ def test_simulate_final_table_custom_params_deterministic():
         iterations=5,
         rng=rng,
         tie_prob=0.2,
+        home_advantage=1.3,
         n_jobs=2,
     )
     rng = np.random.default_rng(9)
@@ -147,6 +148,32 @@ def test_simulate_final_table_custom_params_deterministic():
         iterations=5,
         rng=rng,
         tie_prob=0.2,
+        home_advantage=1.3,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
+def test_custom_params_repeatable():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    rng = np.random.default_rng(11)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.25,
+        home_advantage=1.4,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(11)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.25,
+        home_advantage=1.4,
+        progress=False,
         n_jobs=2,
     )
     pd.testing.assert_frame_equal(t1, t2)


### PR DESCRIPTION
## Summary
- allow tuning home field advantage via CLI or API
- export default parameters from module for convenience
- document new options in README
- ensure deterministic results for custom params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad74f361883258eabe8cca69fde39