### PR TITLE
Add calibration utility and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ example will execute the Monte Carlo iterations using four parallel processes.
 The summary table is automatically saved as `brasileirao.html` in the same
 directory as `main.py`. Pass `--html-output <file>` to choose a custom path.
 Use `--from-date YYYY-MM-DD` to ignore results on or after a given date and
-simulate from that point forward.
+simulate from that point forward. Use `--auto-calibrate` to derive the draw
+percentage and home advantage from recent seasons before running the
+simulation.
 
 The default draw rate and home-field advantage are
 `DEFAULT_TIE_PERCENT` (33.3) and `DEFAULT_HOME_FIELD_ADVANTAGE` (1.0).
 Use `--tie-percent` and `--home-advantage` to override these values on the
 command line. `DEFAULT_JOBS` still defines the parallelism level.
+
+Alternatively, pass `--auto-calibrate` to estimate these parameters from the
+previous seasons included in the `data/` directory. The computed draw rate and
+home advantage are then used for the simulation.
 
 Matches are simulated purely at random with all teams considered equal.
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from simulator import (
     DEFAULT_JOBS,
     DEFAULT_TIE_PERCENT,
     DEFAULT_HOME_FIELD_ADVANTAGE,
+    estimate_parameters,
 )
 
 
@@ -62,6 +63,11 @@ def main() -> None:
         help="relative advantage multiplier for the home team",
     )
     parser.add_argument(
+        "--auto-calibrate",
+        action="store_true",
+        help="estimate parameters from past seasons",
+    )
+    parser.add_argument(
         "--from-date",
         dest="from_date",
         default=None,
@@ -73,6 +79,14 @@ def main() -> None:
         help="path to save summary table as HTML",
     )
     args = parser.parse_args()
+
+    if args.auto_calibrate:
+        season_files = [
+            "data/Brasileirao2022A.txt",
+            "data/Brasileirao2023A.txt",
+            "data/Brasileirao2024A.txt",
+        ]
+        args.tie_percent, args.home_advantage = estimate_parameters(season_files)
 
     matches = parse_matches(args.file)
     if args.from_date:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,6 +12,7 @@ from .simulator import (
     DEFAULT_HOME_FIELD_ADVANTAGE,
     DEFAULT_JOBS,
 )
+from .calibration import estimate_parameters
 
 __all__ = [
     "parse_matches",
@@ -24,4 +25,5 @@ __all__ = [
     "DEFAULT_TIE_PERCENT",
     "DEFAULT_HOME_FIELD_ADVANTAGE",
     "DEFAULT_JOBS",
+    "estimate_parameters",
 ]

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -1,0 +1,47 @@
+"""Automatic parameter estimation utilities."""
+
+from __future__ import annotations
+
+from typing import List
+
+from simulator import parse_matches
+
+
+def estimate_parameters(paths: List[str]) -> tuple[float, float]:
+    """Estimate draw rate and home advantage from past seasons.
+
+    Parameters
+    ----------
+    paths:
+        A list of text file paths containing fixture results in the
+        SportsClubStats format.
+
+    Returns
+    -------
+    tuple[float, float]
+        The ``(tie_percent, home_advantage)`` calculated from the data.
+    """
+
+    total_games = 0
+    home_wins = 0
+    away_wins = 0
+    draws = 0
+
+    for path in paths:
+        df = parse_matches(path)
+        played = df.dropna(subset=["home_score", "away_score"])
+        total_games += len(played)
+        home_wins += (played["home_score"] > played["away_score"]).sum()
+        away_wins += (played["home_score"] < played["away_score"]).sum()
+        draws += (played["home_score"] == played["away_score"]).sum()
+
+    if total_games == 0:
+        raise ValueError("No played games found in provided paths")
+
+    tie_percent = float(100.0 * draws / total_games)
+    if away_wins == 0:
+        home_advantage = 1.0
+    else:
+        home_advantage = float(home_wins / away_wins)
+
+    return tie_percent, home_advantage

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,10 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from calibration import estimate_parameters
+
+
+def test_estimate_parameters_repeatable():
+    tie, ha = estimate_parameters(["data/Brasileirao2024A.txt"])
+    assert round(tie, 4) == 26.5789
+    assert round(ha, 4) == 1.8182
+


### PR DESCRIPTION
## Summary
- add a new `calibration` module to estimate tie percent and home advantage
- expose `--auto-calibrate` flag in the CLI to override parameters
- export `estimate_parameters` via `src/__init__.py`
- document automatic calibration in the README
- test calibration routine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688addb1666083259c00ce1547bc3cbf