### PR TITLE
Add deterministic calibration and summary_table tests

### DIFF
--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -8,3 +8,12 @@ def test_estimate_parameters_repeatable():
     assert round(tie, 4) == 26.5789
     assert round(ha, 4) == 1.8182
 
+
+def test_estimate_parameters_multiple_files_repeatable():
+    tie, ha = estimate_parameters([
+        "data/Brasileirao2023A.txt",
+        "data/Brasileirao2024A.txt",
+    ])
+    assert round(tie, 4) == 26.1842
+    assert round(ha, 4) == 1.7635
+

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -238,4 +238,56 @@ def test_reset_results_from():
     simulator.simulate_chances(reset, iterations=1, progress=False)
 
 
+def test_summary_table_after_reset_deterministic():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    df = simulator.reset_results_from(df, "2024-07-01")
+    rng = np.random.default_rng(7)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.22,
+        home_advantage=1.2,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(7)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.22,
+        home_advantage=1.2,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
+def test_summary_table_after_reset_other_params_deterministic():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    df = simulator.reset_results_from(df, "2024-07-01")
+    rng = np.random.default_rng(8)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.3,
+        home_advantage=1.5,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(8)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        tie_prob=0.3,
+        home_advantage=1.5,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
 


### PR DESCRIPTION
## Summary
- test calibration with multiple season files
- test summary_table reproducibility after reset_results_from with varying parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aed701c208325acf8780af1251aa1