### PR TITLE
Add disclaimer to README and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ so simulations automatically run in parallel. When ``n_jobs`` is greater than
 one, joblib is used to distribute the work across multiple workers. The tie
 percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
 
+## Disclaimer
+
+This simulator is provided for fun and entertainment only. The predictions and
+tables produced are unofficial and may be inaccurate. Do not rely on them for
+betting or other serious purposes.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/main.py
+++ b/main.py
@@ -122,6 +122,11 @@ def main() -> None:
             f"{row['position']:>2d}   {row['team']:15s} {row['points']:^{POINTS_W}d} {title:^{TITLE_W}} {releg:^{REL_W}}"
         )
 
+    print()
+    print(
+        "Predictions are unofficial and provided for entertainment purposes only."
+    )
+    print("Actual outcomes may differ considerably.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- note that results are unofficial and may be inaccurate in README
- print an entertainment disclaimer at the end of the CLI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aeefa42ac83259731387d694c24e0