### PR TITLE
Add team strength estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Alternatively, pass `--auto-calibrate` to estimate these parameters using all
 historical files in the `data/` directory. The computed draw rate and home
 advantage are then used for the simulation.
 
+Use ``estimate_team_strengths`` to calculate attack and defense multipliers for
+each club:
+
+```python
+from calibration import estimate_team_strengths
+strengths = estimate_team_strengths(["data/Brasileirao2024A.txt"])
+```
+
+Pass ``strengths`` via the ``team_params`` argument when calling the simulation
+functions to incorporate team quality into the projections.
+
 Matches are simulated purely at random with all teams considered equal.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,7 +12,7 @@ from .simulator import (
     DEFAULT_HOME_FIELD_ADVANTAGE,
     DEFAULT_JOBS,
 )
-from .calibration import estimate_parameters
+from .calibration import estimate_parameters, estimate_team_strengths
 
 __all__ = [
     "parse_matches",
@@ -26,4 +26,5 @@ __all__ = [
     "DEFAULT_HOME_FIELD_ADVANTAGE",
     "DEFAULT_JOBS",
     "estimate_parameters",
+    "estimate_team_strengths",
 ]

--- a/src/calibration.py
+++ b/src/calibration.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
+
+import pandas as pd
 
 from simulator import parse_matches
 
@@ -45,3 +47,61 @@ def estimate_parameters(paths: List[str]) -> tuple[float, float]:
         home_advantage = float(home_wins / away_wins)
 
     return tie_percent, home_advantage
+
+
+def estimate_team_strengths(paths: List[str]) -> Dict[str, tuple[float, float]]:
+    """Estimate attack and defense multipliers for each team.
+
+    The returned values are normalized so that ``1.0`` represents league
+    average performance.  Values greater than 1.0 indicate stronger attack or
+    weaker defense respectively.
+
+    Parameters
+    ----------
+    paths:
+        A list of text file paths containing historical fixtures with results.
+
+    Returns
+    -------
+    Dict[str, tuple[float, float]]
+        Mapping of team name to ``(attack, defense)`` multipliers.
+    """
+
+    df = [parse_matches(p) for p in paths]
+    if not df:
+        return {}
+
+    played = (
+        pd.concat(df, ignore_index=True)
+        .dropna(subset=["home_score", "away_score"])
+    )
+
+    teams = pd.unique(played[["home_team", "away_team"]].values.ravel())
+    stats = {t: {"gf": 0, "ga": 0, "games": 0} for t in teams}
+
+    for _, row in played.iterrows():
+        ht = row["home_team"]
+        at = row["away_team"]
+        hs = int(row["home_score"])
+        as_ = int(row["away_score"])
+        stats[ht]["gf"] += hs
+        stats[ht]["ga"] += as_
+        stats[ht]["games"] += 1
+        stats[at]["gf"] += as_
+        stats[at]["ga"] += hs
+        stats[at]["games"] += 1
+
+    total_goals = sum(s["gf"] for s in stats.values())
+    total_games = sum(s["games"] for s in stats.values())
+    if total_games == 0:
+        raise ValueError("No played games found in provided paths")
+
+    avg_goals = total_goals / total_games
+
+    strengths: Dict[str, tuple[float, float]] = {}
+    for team, s in stats.items():
+        attack = (s["gf"] / s["games"]) / avg_goals
+        defense = (s["ga"] / s["games"]) / avg_goals
+        strengths[team] = (attack, defense)
+
+    return strengths

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,6 +1,6 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from calibration import estimate_parameters
+from calibration import estimate_parameters, estimate_team_strengths
 
 
 def test_estimate_parameters_repeatable():
@@ -16,4 +16,11 @@ def test_estimate_parameters_multiple_files_repeatable():
     ])
     assert round(tie, 4) == 26.1842
     assert round(ha, 4) == 1.7635
+
+
+def test_estimate_team_strengths_repeatable():
+    strengths = estimate_team_strengths(["data/Brasileirao2024A.txt"])
+    assert len(strengths) == 20
+    assert round(strengths["Palmeiras"][0], 4) == 1.2917
+    assert round(strengths["Fluminense"][1], 4) == 0.8396
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import pytest
 from simulator import parse_matches, league_table, simulate_chances
+from calibration import estimate_team_strengths
 import simulator
 
 
@@ -284,6 +285,30 @@ def test_summary_table_after_reset_other_params_deterministic():
         rng=rng,
         tie_prob=0.3,
         home_advantage=1.5,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
+def test_team_params_repeatable():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    params = estimate_team_strengths(["data/Brasileirao2024A.txt"])
+    rng = np.random.default_rng(100)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        team_params=params,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(100)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        team_params=params,
         progress=False,
         n_jobs=2,
     )


### PR DESCRIPTION
## Summary
- add `estimate_team_strengths` helper for calibrating attack/defense values
- allow simulations to accept `team_params` for strength-weighted results
- document new functionality in README
- test calibration and simulator with team parameters

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af1dad7f883259c29c54580434897