### PR TITLE
Add validation for simulation parameters

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -218,6 +218,11 @@ def _simulate_table(
 ) -> pd.DataFrame:
     """Simulate remaining fixtures with fixed home advantage."""
 
+    if not 0.0 <= tie_prob <= 1.0:
+        raise ValueError("tie_prob must be between 0 and 1")
+    if home_advantage <= 0:
+        raise ValueError("home_advantage must be greater than zero")
+
     sims: list[dict] = []
 
     for _, row in remaining.iterrows():

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -132,6 +132,43 @@ def test_simulate_table_no_draws_when_zero_tie():
     assert table["draws"].sum() == 0
 
 
+def _minimal_matches():
+    played = pd.DataFrame(
+        [],
+        columns=["date", "home_team", "away_team", "home_score", "away_score"],
+    )
+    remaining = pd.DataFrame(
+        [{"date": "2025-01-01", "home_team": "A", "away_team": "B"}]
+    )
+    return played, remaining
+
+
+def test_simulate_table_invalid_tie_prob():
+    played, remaining = _minimal_matches()
+    rng = np.random.default_rng(1)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, tie_prob=-0.1)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, tie_prob=1.1)
+
+
+def test_simulate_table_invalid_home_advantage():
+    played, remaining = _minimal_matches()
+    rng = np.random.default_rng(2)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, home_advantage=0)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, home_advantage=-1)
+
+
+def test_simulate_chances_invalid_params():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    with pytest.raises(ValueError):
+        simulator.simulate_chances(df, iterations=1, tie_prob=2.0, progress=False)
+    with pytest.raises(ValueError):
+        simulator.simulate_chances(df, iterations=1, home_advantage=0, progress=False)
+
+
 def test_simulate_final_table_custom_params_deterministic():
     df = parse_matches("data/Brasileirao2024A.txt")
     rng = np.random.default_rng(9)


### PR DESCRIPTION
## Summary
- validate `tie_prob` and `home_advantage` in `_simulate_table`
- test invalid parameters raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af36557c4832585a11c59620ff3c7