### PR TITLE
Introduce Poisson goal simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The default draw rate and home-field advantage are
 Use `--tie-percent` and `--home-advantage` to override these values on the
 command line. `DEFAULT_JOBS` still defines the parallelism level.
 
+Pass `--home-goals-mean` and `--away-goals-mean` to sample scores from Poisson
+distributions with the given expected values instead of the basic win/draw/loss
+model. These options can also be provided programmatically via the simulation
+functions.
+
 Alternatively, pass `--auto-calibrate` to estimate these parameters using all
 historical files in the `data/` directory. The computed draw rate and home
 advantage are then used for the simulation.
@@ -46,7 +51,9 @@ strengths = estimate_team_strengths(["data/Brasileirao2024A.txt"])
 Pass ``strengths`` via the ``team_params`` argument when calling the simulation
 functions to incorporate team quality into the projections.
 
-Matches are simulated purely at random with all teams considered equal.
+By default matches are simulated purely at random with all teams considered
+equal. When expected goals are supplied the scores are drawn from Poisson
+distributions using those averages.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.
 All of these metrics are derived from a single Monte Carlo loop so that title chances, relegation odds and projected points remain consistent.
@@ -89,6 +96,8 @@ degree of parallelism. By default ``n_jobs`` is set to the number of CPU cores,
 so simulations automatically run in parallel. When ``n_jobs`` is greater than
 one, joblib is used to distribute the work across multiple workers. The tie
 percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
+Provide expected goal values via ``home_goals_mean`` and ``away_goals_mean`` to
+enable Poisson-based scoring.
 
 ## Disclaimer
 

--- a/main.py
+++ b/main.py
@@ -64,6 +64,18 @@ def main() -> None:
         help="relative advantage multiplier for the home team",
     )
     parser.add_argument(
+        "--home-goals-mean",
+        type=float,
+        default=None,
+        help="expected goals for the home side when using Poisson scoring",
+    )
+    parser.add_argument(
+        "--away-goals-mean",
+        type=float,
+        default=None,
+        help="expected goals for the away side when using Poisson scoring",
+    )
+    parser.add_argument(
         "--auto-calibrate",
         action="store_true",
         help="estimate parameters from past seasons",
@@ -104,6 +116,8 @@ def main() -> None:
         progress=args.progress,
         tie_prob=tie_prob,
         home_advantage=home_adv,
+        home_goals_mean=args.home_goals_mean,
+        away_goals_mean=args.away_goals_mean,
         n_jobs=args.jobs,
     )
     if args.html_output:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -352,4 +352,38 @@ def test_team_params_repeatable():
     pd.testing.assert_frame_equal(t1, t2)
 
 
+def test_poisson_mode_repeatable():
+    df = parse_matches("data/Brasileirao2024A.txt")
+    rng = np.random.default_rng(555)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.5,
+        away_goals_mean=1.2,
+        progress=False,
+        n_jobs=2,
+    )
+    rng = np.random.default_rng(555)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rng=rng,
+        home_goals_mean=1.5,
+        away_goals_mean=1.2,
+        progress=False,
+        n_jobs=2,
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
+def test_simulate_table_invalid_goal_means():
+    played, remaining = _minimal_matches()
+    rng = np.random.default_rng(3)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, home_goals_mean=0)
+    with pytest.raises(ValueError):
+        simulator._simulate_table(played, remaining, rng, away_goals_mean=-1)
+
+
 


### PR DESCRIPTION
## Summary
- simulate goals using Poisson distributions when goal means are provided
- expose `home_goals_mean` and `away_goals_mean` in CLI and simulation API
- document new Poisson options in the README
- cover Poisson mode with new unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af5f9acdc8325bc4d64076d98f5a0