### PR TITLE
Add xWins column

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,14 +126,15 @@ def main() -> None:
     TITLE_W = 7
     REL_W = 10
     POINTS_W = len("xPts")
+    WINS_W = len("xWins")
     print(
-        f"{'Pos':>3}  {'Team':15s} {'xPts':^{POINTS_W}} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}"
+        f"{'Pos':>3}  {'Team':15s} {'xPts':^{POINTS_W}} {'xWins':^{WINS_W}} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}"
     )
     for _, row in summary.iterrows():
         title = f"{row['title']:.2%}"
         releg = f"{row['relegation']:.2%}"
         print(
-            f"{row['position']:>2d}   {row['team']:15s} {row['points']:^{POINTS_W}d} {title:^{TITLE_W}} {releg:^{REL_W}}"
+            f"{row['position']:>2d}   {row['team']:15s} {row['points']:^{POINTS_W}d} {row['wins']:^{WINS_W}d} {title:^{TITLE_W}} {releg:^{REL_W}}"
         )
 
 if __name__ == "__main__":

--- a/src/simulator.py
+++ b/src/simulator.py
@@ -530,6 +530,7 @@ def summary_table(
     title_counts = {t: 0 for t in teams}
     relegated = {t: 0 for t in teams}
     points_totals = {t: 0.0 for t in teams}
+    wins_totals = {t: 0.0 for t in teams}
 
     played_df = matches.dropna(subset=["home_score", "away_score"])
     remaining = matches[
@@ -555,6 +556,7 @@ def summary_table(
             relegated[team] += 1
         for _, row in table.iterrows():
             points_totals[row["team"]] += row["points"]
+            wins_totals[row["team"]] += row["wins"]
 
     rows = []
     for team in teams:
@@ -562,6 +564,7 @@ def summary_table(
             {
                 "team": team,
                 "points": points_totals[team] / iterations,
+                "wins": wins_totals[team] / iterations,
                 "title": title_counts[team] / iterations,
                 "relegation": relegated[team] / iterations,
             }
@@ -571,4 +574,5 @@ def summary_table(
     df = df.sort_values("points", ascending=False).reset_index(drop=True)
     df["position"] = range(1, len(df) + 1)
     df["points"] = df["points"].round().astype(int)
-    return df[["position", "team", "points", "title", "relegation"]]
+    df["wins"] = df["wins"].round().astype(int)
+    return df[["position", "team", "points", "wins", "title", "relegation"]]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -96,7 +96,7 @@ def test_summary_table_deterministic():
         df, iterations=5, rng=rng, progress=False, n_jobs=2
     )
     pd.testing.assert_frame_equal(table1, table2)
-    assert {"position", "team", "points", "title", "relegation"}.issubset(table1.columns)
+    assert {"position", "team", "points", "wins", "title", "relegation"}.issubset(table1.columns)
 
 
 def test_league_table_tiebreakers():


### PR DESCRIPTION
## Summary
- add expected wins to summary output
- adjust CLI printout
- check for xWins column in tests

## Testing
- `pytest -q`
- `python main.py --simulations 1 --no-progress --seed 0`

------
https://chatgpt.com/codex/tasks/task_e_688bc966b3548325b1844fe18e6ba31e