### PR TITLE
Fix summary table sort

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -571,7 +571,7 @@ def summary_table(
         )
 
     df = pd.DataFrame(rows)
-    df = df.sort_values("points", ascending=False).reset_index(drop=True)
+    df = df.sort_values(["points", "wins"], ascending=[False, False]).reset_index(drop=True)
     df["position"] = range(1, len(df) + 1)
     df["points"] = df["points"].round().astype(int)
     df["wins"] = df["wins"].round().astype(int)


### PR DESCRIPTION
## Summary
- sort `summary_table()` by wins when points are equal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bcc37c05c832598637c74a06d09f6