### PR TITLE
Remove gambling disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ percentage and home advantage are fixed at their defaults of 33.3% and 1.0.
 Provide expected goal values via ``home_goals_mean`` and ``away_goals_mean`` to
 enable Poisson-based scoring.
 
-## Disclaimer
-
-This simulator is provided for fun and entertainment only. The predictions and
-tables produced are unofficial and may be inaccurate. Do not rely on them for
-betting or other serious purposes.
-
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- drop the betting disclaimer from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c1efdf7408325a1119a547161a042