### PR TITLE
Fix table sorting order

### DIFF
--- a/src/simulator.py
+++ b/src/simulator.py
@@ -585,7 +585,7 @@ def summary_table(
         )
 
     df = pd.DataFrame(rows)
-    df = df.sort_values(["points", "wins"], ascending=[False, False]).reset_index(drop=True)
+    df = df.sort_values(["points", "wins", "gd"], ascending=[False, False, False]).reset_index(drop=True)
     df["position"] = range(1, len(df) + 1)
     df["points"] = df["points"].round().astype(int)
     df["wins"] = df["wins"].round().astype(int)


### PR DESCRIPTION
## Summary
- sort summary table by goal difference after points and wins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c27f9ec308325bdeb3fb9e5f9dd85